### PR TITLE
Bump liqpool dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,7 +588,7 @@ dependencies = [
  "sha2 0.10.2",
  "stellar-contract-sdk",
  "stellar-liqpool-contract",
- "stellar-token-contract",
+ "stellar-token-contract 0.0.0 (git+https://github.com/stellar/rs-stellar-token-contract?rev=3e73379)",
  "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=94e01c7b)",
 ]
 
@@ -601,7 +601,7 @@ dependencies = [
  "rand",
  "stellar-contract-sdk",
  "stellar-single-offer-contract",
- "stellar-token-contract",
+ "stellar-token-contract 0.0.0 (git+https://github.com/stellar/rs-stellar-token-contract?rev=03959d2)",
  "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=94e01c7b)",
 ]
 
@@ -613,6 +613,17 @@ dependencies = [
  "ed25519-dalek",
  "num-bigint",
  "sha2 0.10.2",
+ "stellar-contract-sdk",
+ "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=94e01c7b)",
+]
+
+[[package]]
+name = "stellar-token-contract"
+version = "0.0.0"
+source = "git+https://github.com/stellar/rs-stellar-token-contract?rev=3e73379#3e7337996851283c6cf9746dba159d34fe3455ef"
+dependencies = [
+ "ed25519-dalek",
+ "num-bigint",
  "stellar-contract-sdk",
  "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=94e01c7b)",
 ]

--- a/liquidity_pool/Cargo.toml
+++ b/liquidity_pool/Cargo.toml
@@ -15,7 +15,7 @@ external = ["stellar-token-contract/external", "dep:ed25519-dalek", "dep:num-big
 ed25519-dalek = { version = "1.0.1", optional = true }
 num-bigint = { version = "0.4", optional = true }
 sha2 = { version = "0.10.2", optional = true }
-stellar-token-contract = { git = "https://github.com/stellar/rs-stellar-token-contract", rev = "03959d2", default-features = false  }
+stellar-token-contract = { git = "https://github.com/stellar/rs-stellar-token-contract", rev = "3e73379", default-features = false  }
 stellar-contract-sdk = { git = "https://github.com/stellar/rs-stellar-contract-sdk", rev = "d279737" }
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "94e01c7b", features = ["next", "std"], optional = true }
 

--- a/liquidity_pool/src/test.rs
+++ b/liquidity_pool/src/test.rs
@@ -12,23 +12,16 @@ fn generate_keypair() -> Keypair {
 }
 
 fn make_auth(kp: &Keypair, msg: &token::Message) -> token::Authorization {
-    use token::{Authorization, Ed25519Authorization};
     let signature = msg.sign(kp).unwrap();
-    Authorization::Ed25519(Ed25519Authorization {
-        nonce: msg.0.clone(),
-        signature,
-    })
+    token::Authorization::Ed25519(signature)
 }
 
 fn make_keyed_auth(kp: &Keypair, msg: &token::Message) -> token::KeyedAuthorization {
-    use token::{Ed25519Authorization, KeyedAuthorization, KeyedEd25519Authorization};
+    use token::{KeyedAuthorization, KeyedEd25519Authorization};
     let signature = msg.sign(kp).unwrap();
     KeyedAuthorization::Ed25519(KeyedEd25519Authorization {
         public_key: kp.public.to_bytes(),
-        auth: Ed25519Authorization {
-            nonce: msg.0.clone(),
-            signature,
-        },
+        signature,
     })
 }
 


### PR DESCRIPTION
### What

Bump token to newest version.

### Why

Don't get stale, make sure that new signatures work.

### Known limitations

None